### PR TITLE
Update source to compile in linux/arm64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 _build/
 bpftrace-hol/
 bpftrace-hol.tar.gz
+core
 bpfhol
 closeall
 mapit

--- a/CODE/core/core.cc
+++ b/CODE/core/core.cc
@@ -4,6 +4,7 @@
 #include <vector>
 #include <syncstream>
 #include <cstdlib>
+#include <sys/syscall.h>
 #include <sys/prctl.h>
 
 __attribute__((optnone))

--- a/CODE/kprobes/kprobeme.cc
+++ b/CODE/kprobes/kprobeme.cc
@@ -91,19 +91,19 @@ int main() {
   char buf[1024];
 
   for (auto i = 0; i < INT_MAX; ++i) {
-    fd = ::syscall(SYS_open, "/proc/uptime", O_RDONLY);
+    fd = ::open("/proc/uptime", O_RDONLY);
     if (fd < 0) {
       ::perror("open");
     }
 
-    err = ::syscall(SYS_read, fd, &buf[0], sizeof(buf));
+    err = ::read(fd, &buf[0], sizeof(buf));
     if (err < 0) {
       ::perror("read");
     }
 
     // Leaks 1/5 file descriptors
     if (i % 5) {
-      err = ::syscall(SYS_close, fd);
+      err = ::close(fd);
       if (err < 0) {
         ::perror("close");
       }

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Example solutions for all lab exercises are provided in the [solutions document]
 
 Please use your instructor to discuss any issues or problems you may have. Everyone including them is on a learning curve with bpftrace so your question or problem will always be valuable.
 
+### Compiling the source on your own
+
+Run `bash package.sh`, then cd into `_build/` and run `./bpfhol`
+
 ### Labs
 
 <!---


### PR DESCRIPTION
Tested:

```
bash package.sh
...
_build/
_build/bpfhol
_build/load_generators/
_build/load_generators/scripts/
_build/load_generators/utils/
_build/load_generators/utils/allprobes.py
_build/load_generators/uprobes/
_build/load_generators/uprobes/uprobeme
_build/load_generators/syscalls/
_build/load_generators/syscalls/tempfiles
_build/load_generators/syscalls/mapit
_build/load_generators/syscalls/closeall
_build/load_generators/usdt/
_build/load_generators/usdt/thrift/
_build/load_generators/usdt/thrift/cpp2/
_build/load_generators/usdt/thrift/if/
_build/load_generators/usdt/usdt-passwd
_build/load_generators/core/
_build/load_generators/core/core
_build/load_generators/kprobes/
_build/load_generators/kprobes/kprobeme
Output is: bpftrace-hol.tar.gz

cd _build
./bpfhol
1. core
2. syscalls
3. kernel
4. usdt
5. uprobes
8. stop current generator
9. exit 

 file ./bpfhol
./bpfhol: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=cb8b246fa5585ee07652276187799b98ece9864a, for GNU/Linux 3.7.0, not stripped
```

Which is the same output as https://bpftrace.org/hol/intro.